### PR TITLE
Support SASS variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules/
 coverage/
+.vscode/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scry-css",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Suggestion engine for CSS variables and mixins",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "colour": "0.7.1",
     "commander": "2.9.0",
-    "fuzzaldrin": "^2.1.0",
+    "fuzzaldrin": "2.1.0",
     "fuzzy": "0.1.1",
     "lodash": "4.14.1",
     "node-dir": "0.1.15",
@@ -45,13 +45,13 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "coveralls": "^2.11.12",
+    "coveralls": "2.11.12",
     "eslint": "3.2.0",
     "eslint-config-airbnb-base": "5.0.1",
     "eslint-plugin-import": "1.12.0",
     "istanbul": "0.4.4",
     "mocha": "2.5.3",
-    "mocha-lcov-reporter": "^1.2.0",
+    "mocha-lcov-reporter": "1.2.0",
     "pre-commit": "1.1.3"
   },
   "engines": {

--- a/src/bin/scry-css.js
+++ b/src/bin/scry-css.js
@@ -5,7 +5,7 @@ const PipelineRunner = require('../pipeline/runner')
 const _ = require('lodash')
 
 program
-  .version('scry-css 0.2.2')
+  .version('scry-css 0.3.0')
   .usage('[options] <type> <dir> <file...>')
   .option(
     '-r --reporter [reporter]',

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,0 +1,7 @@
+const sass = require('./sass-variable')
+const less = require('./less-variable')
+
+module.exports = {
+  less,
+  sass,
+}

--- a/src/parsers/sass-variable.js
+++ b/src/parsers/sass-variable.js
@@ -1,0 +1,16 @@
+const _ = require('lodash')
+
+const SASS_VARIABLE_REGEX = /^\$([a-z0-9\-_]*):(\s*)([#\(\):,%a-z0-9]*);/i
+
+module.exports = {
+  parse: (line) => {
+    const { 0: all, 1: variable, 3: value } = SASS_VARIABLE_REGEX.exec(line.string) || []
+
+    return _.isEmpty(all) ? null : {
+      variable,
+      value,
+      lineNumber: line.lineNumber,
+    }
+  },
+}
+

--- a/src/pipeline/intelli/extract.js
+++ b/src/pipeline/intelli/extract.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 const Promise = require('promised-io/promise')
-const { parse } = require('../../parsers/less-variable')
+const Parsers = require('../../parsers')
 const { lines } = require('../../io').LineReader
 
 module.exports = (filesByDirectory, intelliConfig) => {
@@ -13,11 +13,12 @@ module.exports = (filesByDirectory, intelliConfig) => {
       return linesByFilePath
     }, {}))
   }, {})
+
   Promise.allKeys(promises).then((linesByFile) => {
     deferred.resolve(_.reduce(linesByFile, (result, fileLines, filePath) => {
       result[filePath] = _
         .chain(fileLines)
-        .map((fileLine) => parse(fileLine))
+        .map((fileLine) => Parsers[intelliConfig.stack].parse(fileLine))
         .filter((fileLine) => !_.isEmpty(fileLine))
         .value()
 

--- a/src/pipeline/intelli/index.js
+++ b/src/pipeline/intelli/index.js
@@ -1,4 +1,7 @@
+const intelExtract = require('./extract')
+const intelInput = require('./input')
+
 module.exports = {
-  intelExtract: require('./extract'),
-  intelInput: require('./input')
+  intelExtract,
+  intelInput,
 }

--- a/test/fixtures/only-variables.js
+++ b/test/fixtures/only-variables.js
@@ -1,6 +1,6 @@
 module.exports = {
   lines: [
     '@line-height: 24px;',
-    '@max-width:  100%;'
-  ]
+    '@max-width:  100%;',
+  ],
 }

--- a/test/fixtures/pipeline/intelli/extract/has-variables.sass
+++ b/test/fixtures/pipeline/intelli/extract/has-variables.sass
@@ -1,0 +1,12 @@
+/*
+ * Global SASS file
+ *
+ */
+
+$global-margin:         1px solid #fff;
+
+$global-white-space:    nowrap;
+
+$global-font-family:    Helvetica;
+
+$global-background: #fff;

--- a/test/fixtures/pipeline/intelli/extract/no-variables.sass
+++ b/test/fixtures/pipeline/intelli/extract/no-variables.sass
@@ -1,0 +1,5 @@
+.some-class {
+  p {
+    text-align: left;
+  }
+}

--- a/test/fixtures/pipeline/intelli/extract/sass-base.js
+++ b/test/fixtures/pipeline/intelli/extract/sass-base.js
@@ -1,0 +1,34 @@
+const path = require('path')
+
+const absolutePath1 = path.resolve('test/fixtures/pipeline/intelli/extract/has-variables.sass')
+const absolutePath2 = path.resolve('test/fixtures/pipeline/intelli/extract/no-variables.sass')
+
+module.exports = {
+  input: {
+    "test/fixtures/pipeline/intelli/extract": [
+      absolutePath1,
+      absolutePath2,
+    ],
+    "test/fixtures/pipeline/find-candidates": []
+  },
+  output: {
+    [absolutePath1]: [
+      {
+        "variable": "global-white-space",
+        "value": "nowrap",
+        "lineNumber": 8,
+      },
+      {
+        "variable": "global-font-family",
+        "value": "Helvetica",
+        "lineNumber": 10,
+      },
+      {
+        "variable": "global-background",
+        "value": "#fff",
+        "lineNumber": 12,
+      }
+    ],
+    [absolutePath2]: []
+  }
+}

--- a/test/parsers/less-variable.js
+++ b/test/parsers/less-variable.js
@@ -1,4 +1,4 @@
-const LessVariableParser = require('../../src/parsers/less-variable')
+const { less: LessVariableParser } = require('../../src/parsers')
 
 describe('LESS Variable parser', function () {
   describe('#parse', function () {

--- a/test/parsers/sass-variable.js
+++ b/test/parsers/sass-variable.js
@@ -1,0 +1,81 @@
+/* global describe */
+/* global expect */
+/* global it */
+const SassParser = require('../../src/parsers/sass-variable')
+
+describe('SASS Variable parser', () => {
+  describe('#parse', () => {
+    it('should parse variable with a hex color value', () => {
+      expect(SassParser.parse({
+        string: '$link-color:        #428bca;',
+        lineNumber: 2,
+      })).to.deep.equal({
+        variable: 'link-color',
+        value: '#428bca',
+        lineNumber: 2,
+      })
+    })
+
+    it('should parse variable with a text color value', () => {
+      expect(SassParser.parse({
+        string: '$some-color: red;',
+        lineNumber: 24,
+      })).to.deep.equal({
+        variable: 'some-color',
+        value: 'red',
+        lineNumber: 24,
+      })
+    })
+
+    it('should parse variable with a rgba color value', () => {
+      expect(SassParser.parse({
+        string: '$widget-b-color:     rgba(0,0,0,255);',
+        lineNumber: 51,
+      })).to.deep.equal({
+        variable: 'widget-b-color',
+        value: 'rgba(0,0,0,255)',
+        lineNumber: 51,
+      })
+    })
+
+    it('should parse variable with a px value', () => {
+      expect(SassParser.parse({
+        string: '$normal-line-height:   12px;',
+        lineNumber: 32,
+      })).to.deep.equal({
+        variable: 'normal-line-height',
+        value: '12px',
+        lineNumber: 32,
+      })
+    })
+
+    it('should parse variable with a percentage value', () => {
+      expect(SassParser.parse({
+        string: '$widget-min-width: 50%;',
+        lineNumber: 10,
+      })).to.deep.equal({
+        variable: 'widget-min-width',
+        value: '50%',
+        lineNumber: 10,
+      })
+    })
+
+    it('should parse variable with a text value', () => {
+      expect(SassParser.parse({
+        string: '$widget-align: normal;',
+        lineNumber: 42,
+      })).to.deep.equal({
+        variable: 'widget-align',
+        value: 'normal',
+        lineNumber: 42,
+      })
+    })
+
+    it('should not parse a non variable declaration line', () => {
+      expect(SassParser.parse({
+        string: '.icon-a {',
+        lineNumber: 2,
+      })).to.equal(null)
+    })
+  })
+})

--- a/test/pipeline/intelli/extract.js
+++ b/test/pipeline/intelli/extract.js
@@ -1,10 +1,23 @@
+/* global describe */
+/* global expect */
+/* global it */
 const extract = require('../../../src/pipeline/intelli/extract')
-const fixture = require('../../fixtures/pipeline/intelli/extract/base')
+const lessFixture = require('../../fixtures/pipeline/intelli/extract/base')
+const sassFixture = require('../../fixtures/pipeline/intelli/extract/sass-base')
+const intelliConfig = require('../../../src/config')
 
 describe('#extract', () => {
   it('should extract LESS variables from given directories', (done) => {
-    extract(fixture.input, {stack: 'less'}).then((result) => {
-      expect(result).to.deep.equal(fixture.output)
+    extract(lessFixture.input, intelliConfig.less).then((result) => {
+      expect(result).to.deep.equal(lessFixture.output)
+
+      done()
+    })
+  })
+
+  it('should extract SASS variables from given directories', (done) => {
+    extract(sassFixture.input, intelliConfig.sass).then((result) => {
+      expect(result).to.deep.equal(sassFixture.output)
 
       done()
     })

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
-const {expect, assert} = require('chai')
+const { expect, assert } = require('chai')
 
 global.expect = expect
 global.assert = assert


### PR DESCRIPTION
Should work the same way, except SASS variables start with `$` instead of `@` in LESS.
