### PR TITLE
Replace promised-io with Bluebird, as per #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "mixins"
   ],
   "dependencies": {
+    "bluebird": "^3.4.6",
     "colour": "0.7.1",
     "commander": "2.9.0",
     "fuzzaldrin": "2.1.0",
     "lodash": "4.14.1",
-    "node-dir": "0.1.15",
-    "promised-io": "0.3.5"
+    "node-dir": "0.1.15"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/src/io/dir-walker.js
+++ b/src/io/dir-walker.js
@@ -1,5 +1,5 @@
 const dir = require('node-dir')
-const Promise = require('promised-io/promise')
+const Promise = require('bluebird')
 const path = require('path')
 const _ = require('lodash')
 
@@ -8,20 +8,18 @@ function files(dirPath, fileExtension) {
     throw new Error('fileExtension is mandatory!')
   }
 
-  const deferred = new Promise.Deferred()
+  return new Promise((resolve, reject) => {
+    dir.files(path.resolve(dirPath), (err, fileList) => {
+      if (err) {
+        reject(err)
+        return
+      }
 
-  dir.files(path.resolve(dirPath), (err, fileList) => {
-    if (err) {
-      deferred.reject(err)
-      return
-    }
-
-    deferred.resolve(
-      fileList.filter(file => !_.startsWith(file, '.') && _.endsWith(file, fileExtension))
-    )
+      resolve(
+        fileList.filter(file => !_.startsWith(file, '.') && _.endsWith(file, fileExtension))
+      )
+    })
   })
-
-  return deferred.promise
 }
 
 module.exports = {

--- a/src/io/line-reader.js
+++ b/src/io/line-reader.js
@@ -2,30 +2,29 @@ const readline = require('readline')
 const fs = require('fs')
 const _ = require('lodash')
 const path = require('path')
-const Deferred = require('promised-io/promise').Deferred
+const Promise = require('bluebird')
 
 function lines(filePath) {
-  const deferred = new Deferred()
-  const lineReader = readline.createInterface({
-    input: fs.createReadStream(path.resolve(filePath)),
-  })
+  return new Promise((resolve) => {
+    const lineReader = readline.createInterface({
+      input: fs.createReadStream(path.resolve(filePath)),
+    })
 
-  const data = []
-  let lineNumber = 1
-  lineReader.on('line', (line) => {
-    const value = line.trim()
-    data.push({
-      string: value,
-      isEmpty: _.isEmpty(value),
-      lineNumber: lineNumber++,
+    const data = []
+    let lineNumber = 1
+    lineReader.on('line', (line) => {
+      const value = line.trim()
+      data.push({
+        string: value,
+        isEmpty: _.isEmpty(value),
+        lineNumber: lineNumber++,
+      })
+    })
+
+    lineReader.on('close', () => {
+      resolve(data)
     })
   })
-
-  lineReader.on('close', () => {
-    deferred.resolve(data)
-  })
-
-  return deferred.promise
 }
 
 module.exports = {

--- a/src/pipeline/extract-lines.js
+++ b/src/pipeline/extract-lines.js
@@ -1,17 +1,15 @@
 const { LineReader } = require('../io')
-const Promise = require('promised-io/promise')
+const Promise = require('bluebird')
 
-module.exports = (inputFilePaths) => {
-  const result = { files: {} }
-  const deferred = new Promise.Deferred()
+module.exports = (inputFilePaths) =>
+  new Promise((resolve) => {
+    const result = { files: {} }
 
-  const promises = inputFilePaths.map((inputFilePath) => (LineReader.lines(inputFilePath)))
-  Promise.all(promises).then((results) => {
-    inputFilePaths.forEach((inputFilePath, index) => {
-      result.files[inputFilePath] = results[index]
+    const promises = inputFilePaths.map((inputFilePath) => (LineReader.lines(inputFilePath)))
+    Promise.all(promises).then((results) => {
+      inputFilePaths.forEach((inputFilePath, index) => {
+        result.files[inputFilePath] = results[index]
+      })
+      resolve(result)
     })
-    deferred.resolve(result)
   })
-
-  return deferred.promise
-}

--- a/src/pipeline/intelli/input.js
+++ b/src/pipeline/intelli/input.js
@@ -1,16 +1,15 @@
 const { files } = require('../../io/dir-walker')
-const Promise = require('promised-io/promise')
+const Promise = require('bluebird')
 
-module.exports = (dirPaths, intelliConfig) => {
-  const deferred = new Promise.Deferred()
+module.exports = (dirPaths, intelliConfig) =>
+  new Promise((resolve) => {
+    const filesByDirectory = {}
+    Promise.all(dirPaths.map((dirPath) => files(dirPath, intelliConfig.fileExtension)))
+      .then((results) => {
+        results.forEach((fileList, index) => {
+          filesByDirectory[dirPaths[index]] = fileList
+        })
 
-  let filesByDirectory = {}
-  Promise.all(dirPaths.map((dirPath) => files(dirPath, intelliConfig.fileExtension))).then((results) => {
-    results.map((fileList, index) => {
-      filesByDirectory[dirPaths[index]] = fileList
-    })
-    deferred.resolve(filesByDirectory)
+        resolve(filesByDirectory)
+      })
   })
-
-  return deferred.promise
-}

--- a/src/pipeline/runner.js
+++ b/src/pipeline/runner.js
@@ -1,5 +1,5 @@
 const _ = require('lodash')
-const Promise = require('promised-io/promise')
+const Promise = require('bluebird')
 
 const { intelInput, intelExtract } = require('./intelli')
 const findCandidates = require('./find-candidates')


### PR DESCRIPTION
Tests/linter pass so it should be fine. I do think src/pipeline/intelli/extract.js has become a little cluttered, but I couldn't think of a better way right now.
